### PR TITLE
Fix basic authentication

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/publishers/AbstractHttpHelmChartPublisher.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/publishers/AbstractHttpHelmChartPublisher.kt
@@ -111,7 +111,7 @@ internal abstract class AbstractHttpHelmChartPublisher(
 
     private fun SerializablePasswordCredentials.createAuthInterceptor(): Interceptor = Interceptor { chain ->
         val request = chain.request().newBuilder()
-            .addHeader("Authorization", "Basic ${Credentials.basic(username, password ?: "")}")
+            .addHeader("Authorization", "${Credentials.basic(username, password ?: "")}")
             .build()
         chain.proceed(request)
     }


### PR DESCRIPTION
Like you can see here https://github.com/square/okhttp/blob/19771365f25d986d125478a75c15d24d6e285e12/okhttp/src/main/kotlin/okhttp3/Credentials.kt#L32 the http client is adding the keyword Basic already. This results into "Basic Basic xyz"